### PR TITLE
Change parameter list in FunctionType in ValueImpl.__add__

### DIFF
--- a/tensorflow_federated/python/core/impl/value_impl.py
+++ b/tensorflow_federated/python/core/impl/value_impl.py
@@ -200,7 +200,7 @@ class ValueImpl(value_base.Value):
             computation_building_blocks.Intrinsic(
                 intrinsic_defs.GENERIC_PLUS.uri,
                 computation_types.FunctionType(
-                    [self.type_signature, self.type_signature],
+                    [self.type_signature, other.type_signature],
                     self.type_signature)),
             ValueImpl.get_comp(
                 to_value([self, other], None, self._context_stack))),


### PR DESCRIPTION
Although it cannot perform operations on different types for now, we should use [self.type_signature, other.type_signature] to create a FuncType object as what it really means.