### PR TITLE
Minor typo in installation documentation (test install TensorFlow Federated using pip)

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -54,7 +54,7 @@ Note: To exit the virtual environment, run `deactivate`.
 #### 4. (Optional) Test Tensorflow Federated.
 
 <pre class="prettyprint lang-bsh">
-<code class="devsite-terminal tfo-terminal-venv">python -c "import tensorflow_federated as tff; tff.federated_computation(lambda: 'Hello World')()"</code>
+<code class="devsite-terminal tfo-terminal-venv">python -c "import tensorflow_federated as tff; print(tff.federated_computation(lambda: 'Hello World')())"</code>
 </pre>
 
 Success: TensorFlow Federated is now installed.


### PR DESCRIPTION
This fix missing `print` when testing Tensorflow Federated (install documentation).
It could help #709.