### PR TITLE
Fix unreachable code in federating & composing executors

### DIFF
--- a/tensorflow_federated/python/core/impl/executors/composing_executor.py
+++ b/tensorflow_federated/python/core/impl/executors/composing_executor.py
@@ -321,7 +321,8 @@ class ComposingExecutor(executor_base.Executor):
     elif isinstance(comp.internal_representation, intrinsic_defs.IntrinsicDef):
       coro = getattr(
           self,
-          '_compute_intrinsic_{}'.format(comp.internal_representation.uri))
+          '_compute_intrinsic_{}'.format(comp.internal_representation.uri),
+          None)
       if coro is not None:
         return await coro(arg)
       else:

--- a/tensorflow_federated/python/core/impl/executors/federating_executor.py
+++ b/tensorflow_federated/python/core/impl/executors/federating_executor.py
@@ -363,7 +363,8 @@ class FederatingExecutor(executor_base.Executor):
     elif isinstance(comp.internal_representation, intrinsic_defs.IntrinsicDef):
       coro = getattr(
           self,
-          '_compute_intrinsic_{}'.format(comp.internal_representation.uri))
+          '_compute_intrinsic_{}'.format(comp.internal_representation.uri),
+          None)
       if coro is not None:
         return await coro(arg)
       else:


### PR DESCRIPTION
Add None as `getattr` default in `FederatingExecutor.create_call` & `ComposingExecutor.create_call`. This is necessary to reach the NotImplementedError for intrinsics that aren't supported by these executors.

Happy to add a test on request.