### PR TITLE
gitignore venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Python
 *.py[cod]
 __pycache__/
+venv/
 
 # Bazel
 /.bazelrc


### PR DESCRIPTION
It's standard practice to gitignore local `venv` directories for Python development.