### PR TITLE
fix: tf.random_uniform to tf.random.uniform

### DIFF
--- a/tensorflow_federated/python/research/gans/gan_losses.py
+++ b/tensorflow_federated/python/research/gans/gan_losses.py
@@ -125,7 +125,7 @@ def _wass_grad_penalty_term(real_images,
     differences = gen_images - real_images
     batch_size = tf.shape(differences)[0]
     alpha_shape = [batch_size] + [1] * (differences.shape.ndims - 1)
-    alpha = tf.random_uniform(shape=alpha_shape)
+    alpha = tf.random.uniform(shape=alpha_shape)
     interpolates = real_images + (alpha * differences)
     return interpolates
 


### PR DESCRIPTION
A small fix for the demo on federated GANs to avoid using the deprecated API:
<img width="883" alt="Screen Shot 2020-05-26 at 18 45 09" src="https://user-images.githubusercontent.com/17913919/82921432-09aaaf80-9f81-11ea-8655-0e72dd1235ea.png">
