### PR TITLE
Update README.md

### DIFF
--- a/tensorflow_federated/python/research/optimization/README.md
+++ b/tensorflow_federated/python/research/optimization/README.md
@@ -11,6 +11,7 @@ Some pip packages are required by this library, and may need to be installed:
 pip install absl-py
 pip install attr
 pip install dm-tree
+pip install semantic-version
 pip install numpy
 pip install pandas
 pip install tensorflow


### PR DESCRIPTION
semantic-version seems to be required, when running: bazel run emnist:run_federated -- --total_rounds=100
--client_optimizer=sgd --client_learning_rate=0.1 --server_optimizer=sgd
--server_learning_rate=1.0 --clients_per_round=10 --client_epochs_per_round=1
--experiment_name=emnist_fedavg_experiment