### PR TITLE
avoid 'tf.io.gfile.glob' in CheckpointManager

### DIFF
--- a/tensorflow_federated/python/research/utils/checkpoint_manager.py
+++ b/tensorflow_federated/python/research/utils/checkpoint_manager.py
@@ -221,5 +221,11 @@ class FileCheckpointManager(CheckpointManager):
 
   def _get_all_checkpoint_paths(self) -> List[str]:
     """Returns all the checkpoint paths managed by the instance."""
-    pattern = os.path.join(self._root_dir, '{}*'.format(self._prefix))
-    return tf.io.gfile.glob(pattern)
+    # tensorflow/issues/19378: we cannot use `tf.io.gfile.glob` here 
+    # because it returns directories recursively on Windows.
+    root_dir_entries = tf.io.gfile.listdir(self._root_dir)
+    return [
+        os.path.join(self._root_dir, e)
+        for e in root_dir_entries
+        if e.startswith(self._prefix)
+    ]


### PR DESCRIPTION
'tf.io.gfile.glob' does not support windows:
When matching `*` it collects subfolders which causes an issue when running tff experiments on windows.

see also: https://github.com/tensorflow/tensorflow/issues/19378#issuecomment-412760300