### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/tensorflow_federated/python/core/backends/mapreduce/forms.py
+++ b/tensorflow_federated/python/core/backends/mapreduce/forms.py
@@ -126,7 +126,7 @@ class BroadcastForm(object):
   def summary(self, print_fn=print):
     """Prints a string summary of the `BroadcastForm`.
 
-    Arguments:
+    Args:
       print_fn: Print function to use. It will be called on each line of the
         summary in order to capture the string summary.
     """
@@ -390,7 +390,7 @@ class CanonicalForm(object):
   def summary(self, print_fn=print):
     """Prints a string summary of the `CanonicalForm`.
 
-    Arguments:
+    Args:
       print_fn: Print function to use. It will be called on each line of the
         summary in order to capture the string summary.
     """

--- a/tensorflow_federated/python/core/impl/utils/function_utils.py
+++ b/tensorflow_federated/python/core/impl/utils/function_utils.py
@@ -388,7 +388,7 @@ def _infer_unpack_needed(fn: types.FunctionType,
 _Arguments = Tuple[List[Any], Dict[str, Any]]
 
 
-def _unpack_arg(arg_types, kwarg_types, arg) -> _Args:
+def _unpack_arg(arg_types, kwarg_types, arg) -> _Arguments:
   """Unpacks 'arg' into an argument list based on types."""
   py_typecheck.check_type(arg, (structure.Struct, value_base.Value))
   args = []
@@ -418,7 +418,7 @@ def _unpack_arg(arg_types, kwarg_types, arg) -> _Args:
   return args, kwargs
 
 
-def _ensure_arg_type(parameter_type, arg) -> _Args:
+def _ensure_arg_type(parameter_type, arg) -> _Arguments:
   """Ensures that `arg` matches `parameter_type` before returning it."""
   arg_type = type_conversions.infer_type(arg)
   if not parameter_type.is_assignable_from(arg_type):

--- a/tensorflow_federated/python/core/impl/utils/function_utils.py
+++ b/tensorflow_federated/python/core/impl/utils/function_utils.py
@@ -388,7 +388,7 @@ def _infer_unpack_needed(fn: types.FunctionType,
 _Arguments = Tuple[List[Any], Dict[str, Any]]
 
 
-def _unpack_arg(arg_types, kwarg_types, arg) -> _Arguments:
+def _unpack_arg(arg_types, kwarg_types, arg) -> _Args:
   """Unpacks 'arg' into an argument list based on types."""
   py_typecheck.check_type(arg, (structure.Struct, value_base.Value))
   args = []
@@ -418,7 +418,7 @@ def _unpack_arg(arg_types, kwarg_types, arg) -> _Arguments:
   return args, kwargs
 
 
-def _ensure_arg_type(parameter_type, arg) -> _Arguments:
+def _ensure_arg_type(parameter_type, arg) -> _Args:
   """Ensures that `arg` matches `parameter_type` before returning it."""
   arg_type = type_conversions.infer_type(arg)
   if not parameter_type.is_assignable_from(arg_type):


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue with the TensorFlow codebase: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see tensorflow/tensorflow/pull/45420