### PR TITLE
fix dead links in two readme files

### DIFF
--- a/tensorflow_federated/python/research/gans/README.md
+++ b/tensorflow_federated/python/research/gans/README.md
@@ -1,2 +1,2 @@
 This directory is deprecated. The project has been moved to
-[repository](https://github.com/google-research/federated/gans).
+[repository](https://github.com/google-research/federated/tree/master/gans).

--- a/tensorflow_federated/python/research/triehh/README.md
+++ b/tensorflow_federated/python/research/triehh/README.md
@@ -1,2 +1,2 @@
 This directory is deprecated. The project has been moved to
-[repository](https://github.com/google-research/federated/triehh).
+[repository](https://github.com/google-research/federated/tree/master/triehh).


### PR DESCRIPTION
Hi!
Fixed two links in readme files:
- [gans](https://github.com/tensorflow/federated/tree/master/tensorflow_federated/python/research/gans)
- [triehh](https://github.com/tensorflow/federated/tree/master/tensorflow_federated/python/research/triehh)