### PR TITLE
Fix typo in building_your_own_federated_learning_algorithm.ipynb

### DIFF
--- a/docs/tutorials/building_your_own_federated_learning_algorithm.ipynb
+++ b/docs/tutorials/building_your_own_federated_learning_algorithm.ipynb
@@ -492,7 +492,7 @@
         "\n",
         "The Federated Core (FC) is a set of lower-level interfaces that serve as the foundation for the `tff.learning` API. However, these interfaces are not limited to learning. In fact, they can be used for analytics and many other computations over distributed data.\n",
         "\n",
-        "At a high-level, the federated core is a development environment that enables compactly expressed program logic to combine TensorFlow code with distributed communication operators (such as distributed sums and broadcasts). The goal is to give researchers and practitioners expliict control over the distributed communication in their systems, without requiring system implementation details (such as specifying point-to-point network message exchanges).\n",
+        "At a high-level, the federated core is a development environment that enables compactly expressed program logic to combine TensorFlow code with distributed communication operators (such as distributed sums and broadcasts). The goal is to give researchers and practitioners explicit control over the distributed communication in their systems, without requiring system implementation details (such as specifying point-to-point network message exchanges).\n",
         "\n",
         "One key point is that TFF is designed for privacy-preservation. Therefore, it allows explicit control over where data resides, to prevent unwanted accumulation of data at the centralized server location."
       ]


### PR DESCRIPTION
`expliict` -> `explicit`