### PR TITLE
Update the number of steps on the random dataset in federated_learning_for_text_generation.ipynb to suppress warnings.

### DIFF
--- a/docs/tutorials/federated_learning_for_text_generation.ipynb
+++ b/docs/tutorials/federated_learning_for_text_generation.ipynb
@@ -740,7 +740,7 @@
         "    snippets=tf.constant(\n",
         "        ''.join(np.array(vocab)[random_indexes]), shape=[1, 1]))\n",
         "random_dataset = preprocess(tf.data.Dataset.from_tensor_slices(data))\n",
-        "loss, accuracy = keras_model.evaluate(random_dataset, steps=10, verbose=0)\n",
+        "loss, accuracy = keras_model.evaluate(random_dataset, steps=1, verbose=0)\n",
         "print('Evaluating on completely random data: {a:.3f}'.format(a=accuracy))"
       ]
     },


### PR DESCRIPTION
Update the number of `steps` keyword parameter from 10 to 1 to suppress the following warning:

```
WARNING:tensorflow:Your input ran out of data; interrupting training. Make sure that your dataset or generator can generate at least `steps_per_epoch * epochs` batches (in this case, 10 batches). You may need to use the repeat() function when building your dataset.
```

This matches the size of the `random_indexes` created above (which has the size of : 1 x BATCH_SIZE x (SEQ_LENGTH + 1)).