### PR TITLE
record_aggregation_factory has type `factory.UnweightedAggregationFactory` but is used as type `None`.

### DIFF
--- a/tensorflow_federated/python/aggregators/quantile_estimation.py
+++ b/tensorflow_federated/python/aggregators/quantile_estimation.py
@@ -106,7 +106,7 @@ class PrivateQuantileEstimationProcess(estimation_process.EstimationProcess):
   def __init__(
       self,
       quantile_estimator_query: tfp.QuantileEstimatorQuery,
-      record_aggregation_factory: factory.UnweightedAggregationFactory = None):
+      record_aggregation_factory: factory.UnweightedAggregationFactory):
     """Initializes `PrivateQuantileEstimationProcess`.
 
     Args:


### PR DESCRIPTION


"filename": "tensorflow_federated/python/aggregators/quantile_estimation.py"
"warning_type": "Incompatible variable type [9]",
"warning_message": " record_aggregation_factory is declared to have type `factory.UnweightedAggregationFactory` but is used as type `None`.",
"warning_line": 109
"fix": remove None