### PR TITLE
Python 3.10

### DIFF
--- a/tensorflow_federated/tools/python_package/setup.py
+++ b/tensorflow_federated/tools/python_package/setup.py
@@ -109,6 +109,7 @@ setuptools.setup(
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Scientific/Engineering',
         'Topic :: Scientific/Engineering :: Artificial Intelligence',
@@ -126,5 +127,5 @@ setuptools.setup(
     },
     packages=setuptools.find_packages(exclude=('tools')),
     install_requires=REQUIRED_PACKAGES,
-    python_requires='~=3.9.0',
+    python_requires='>=3.9.0,<3.11',
 )


### PR DESCRIPTION
It seems the direct dependencies of TFF are supported by Python 3.10 now (at least on MacOS and Linux). I built a python 3.10 wheel and it seems to work.

Additionally, as jaxlib is non trivial to compile and we need to maintain our own wheels for arm64 linux (no AVX for docker containers on arm64 (and arm64 linux on Apple Silicon) as well as use these wheels for Windows: 
https://github.com/cloudhan/jax-windows-builder

On a side note it appears given JAX wheels for windows are working, the only hard dependency here that prevents TFF on Windows is TF Compression.
https://github.com/tensorflow/compression

Perhaps thats something that we can all help to fix as well.

Given all of that, perhaps it's a good idea to relax the version requirements here a little bit. I don't know if there are any breaking changes or if the next TFF version might jump up a little higher?