### PR TITLE
Fix a documentation bug

### DIFF
--- a/docs/tutorials/high_performance_simulation_with_kubernetes.ipynb
+++ b/docs/tutorials/high_performance_simulation_with_kubernetes.ipynb
@@ -125,7 +125,7 @@
         "### (Alternately) Launch the Docker Container Locally\n",
         "\n",
         "```\n",
-        "docker run --rm -p 8000:8000 gcr.io/tensorflow-federated/remote-executor-service:latest\n",
+        "docker run --rm -p 80:8000 gcr.io/tensorflow-federated/remote-executor-service:latest\n",
         "```"
       ]
     },


### PR DESCRIPTION
In federated/docs/tutorials/high_performance_simulation_with_kubernetes.ipynb, docker run host port should be 80 instead of 8000, to match both the notebook and the K8s instructions.